### PR TITLE
Add pyproject.toml for compatibility with Python packaging tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "duckypad-configurator"
+version = "3.4.0"
+description = "Configurator and firmware utility for duckyPad devices."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { file = "LICENSE" }
+authors = [{ name = "dekuNukem" }]
+dependencies = [
+    "platformdirs",
+    "hidapi",
+    "pywin32; sys_platform == 'win32'",
+    "psutil",
+    "pyinstaller",
+]
+
+[project.scripts]
+duckypad_config = "duckypad_config:main"
+
+[project.urls]
+Homepage = "https://duckypad.com"
+Repository = "https://github.com/duckyPad/duckyPad-Configurator"
+Documentation = "https://dekunukem.github.io/duckyPad-Pro/doc/getting_started.html"
+

--- a/src/duckypad_config.py
+++ b/src/duckypad_config.py
@@ -1855,4 +1855,8 @@ root.after(500, repeat_func)
 # export_profile_click()
 # import_profile_click()
 
-root.mainloop()
+def main():
+    root.mainloop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows the use of `pipx` and `uvx` for installation on macOS and Linux

The resulting command is:

e.g:
```
uvx --no-cache --from git+https://github.com/hypercorrection/duckypad-configurator duckypad_config
```